### PR TITLE
feat: add discordrpc setting for toggle keeping the rpc active on song pause

### DIFF
--- a/plugins/DiscordRPC/src/index.js
+++ b/plugins/DiscordRPC/src/index.js
@@ -1,9 +1,13 @@
 import { store, intercept, currentMediaItem } from "@neptune";
 import { getMediaURLFromID } from "@neptune/utils";
 import { AutoClient } from "discord-auto-rpc";
+import { html } from "@neptune/voby";
+import { storage } from "@plugin";
 
 const unloadables = [];
 const clientId = "1130698654987067493";
+
+storage.keepRpcOnPause ??= true;
 
 const formatLongString = (s) => (s.length >= 128 ? s.slice(0, 125) + "..." : s);
 
@@ -29,6 +33,10 @@ client.then(() => {
       );
 
       const paused = state.playbackControls.playbackState == "NOT_PLAYING";
+
+      if (paused && storage.keepRpcOnPause === false) {
+        return rpc.clearActivity();
+      }
 
       rpc.setActivity({
         ...(paused
@@ -59,4 +67,25 @@ export async function onUnload() {
     resolvedClient.clearActivity();
     resolvedClient.destroy();
   } catch {}
+}
+
+export function Settings() {
+  setTimeout(() => {
+    const keepRpcOnPauseInput = document.getElementById("keep-rpc-on-pause");
+
+    if(storage.keepRpcOnPause !== keepRpcOnPauseInput.checked){
+      keepRpcOnPauseInput.checked = storage.keepRpcOnPause;
+    }
+  });
+
+  return html`
+    <div style="display:flex;justify-content:space-between">
+      <label for="keep-rpc-on-pause">Keep RPC on pause</label>
+      <input
+        id="keep-rpc-on-pause"
+        type="checkbox"
+        onChange=${(e) => storage.keepRpcOnPause = e.target.checked}
+      />
+    </div>
+  `;
 }


### PR DESCRIPTION
this PR adresses the issue #4 adding the possibility of toggling between keeping or not the rich presence active while a song is paused.