### PR TITLE
fix: fix issue where one letter albums would crash the discordrpc plugin

### DIFF
--- a/plugins/DiscordRPC/src/index.js
+++ b/plugins/DiscordRPC/src/index.js
@@ -18,6 +18,7 @@ client.then(() => {
       const { item: currentlyPlaying, type: mediaType } = currentMediaItem;
 
       const mediaURL = getMediaURLFromID(mediaType === "track" ? currentlyPlaying.album.cover : currentlyPlaying.imageId);
+      const largeImageTextContent = mediaType === "track" ? currentlyPlaying.album.title : currentlyPlaying.title;
 
       const date = new Date();
       const now = (date.getTime() / 1000) | 0;
@@ -42,7 +43,8 @@ client.then(() => {
           "by " + currentlyPlaying.artists.map((a) => a.name).join(", ")
         ),
         largeImageKey: mediaURL,
-        largeImageText: formatLongString(mediaType === 'track' ? currentlyPlaying.album.title : currentlyPlaying.title),
+        // Discord requires largeImageText to be at least 2 characters long. So we add a invisible space to the end of the string if it's only 1 character long.
+        largeImageText: largeImageTextContent.length >= 2 ? formatLongString(largeImageTextContent) : (largeImageTextContent + "‎"),
       });
     })
   );


### PR DESCRIPTION
Addresses the issue discussed in #5.

Discord requires `largeImageText` to be at least 2 characters long, so we need to fill the text with an invisible character if the content length is less than 2.

I don't think there is a case where an album title or song title don't have at least one letter, so I though one invisible character is enough to accomplish the requirement.

Also added a comment in the code for clarification.